### PR TITLE
Renamed API to CollectionWatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Mongo.Collection.get('books').findOne({ name: 'test' });
 
 # API
 
-#### Mongo.Collection.get('name', [options])
+#### CollectionWatcher.get('name', [options])
 
 Returns the collection instance.
 
@@ -23,7 +23,7 @@ Returns the collection instance.
  - options (Object) [optional]
    - options.connection (A connection object)
 
-#### Mongo.Collection.getAll()
+#### CollectionWatcher.getAll()
 
 Returns an array of objects containing:
  - name (The name of the collection)

--- a/mongo-instances-tests.js
+++ b/mongo-instances-tests.js
@@ -1,6 +1,6 @@
 Tinytest.add('basic - works', function (test) {
   Test = new Mongo.Collection('test' + test.id);
   Test.insert({ test: true });
-  var find = Mongo.Collection.get('test' + test.id).find({ test: true });
+  var find = CollectionWatcher.get('test' + test.id).find({ test: true });
   test.equal(find.count(), 1);
 });

--- a/mongo-instances.js
+++ b/mongo-instances.js
@@ -1,3 +1,5 @@
+var root = this.exports || this;
+
 var instances = [];
 // the original collection
 var MongoCollection = Mongo.Collection;
@@ -22,23 +24,25 @@ for (var property in MongoCollection) {
 }
 InfectedMongoCollection.prototype = MongoCollection.prototype;
 
-InfectedMongoCollection.get = function(name, options) {
-  options = options || {};
-  var collection = _.find(instances, function(instance) {
-    if (options.connection)
-      return instance.name === name &&
-        instance.options && instance.options.connection._lastSessionId === options.connection._lastSessionId;
-    return instance.name === name;
-  });
+CollectionWatcher = {
+  get: function(name, options) {
+    options = options || {};
+    var collection = _.find(instances, function(instance) {
+      if (options.connection)
+        return instance.name === name &&
+          instance.options && instance.options.connection._lastSessionId === options.connection._lastSessionId;
+      return instance.name === name;
+    });
 
-  if (! collection)
-    throw new Meteor.Error("Collection not found");
+    if (! collection)
+      throw new Meteor.Error("Collection not found");
 
-  return collection.instance;
-};
+    return collection.instance;
+  },
 
-InfectedMongoCollection.getAll = function() {
-  return instances;
+  getAll: function() {
+    return instances;
+  }
 }
 
 // special-case handle users collection, which might have been created earlier.
@@ -49,3 +53,5 @@ if (Meteor.users) {
     options: undefined
   });
 }
+
+root.CollectionWatcher = CollectionWatcher;


### PR DESCRIPTION
In this version, we moved `get` and `getAll` to a top-level CollectionWatcher interface. Not crazy about the name, but it felt cleaner than polluting the existing Meteor/Mongo namespace any further than necessary.  What do you think?

(Relies on #5)
