### PR TITLE
Add ability to get local collections instance

### DIFF
--- a/mongo-instances-tests.js
+++ b/mongo-instances-tests.js
@@ -68,3 +68,15 @@ Tinytest.add('users - can Mongo.Collection.get Meteor.users instance', function 
   test.instanceOf(Mongo.Collection.get('users'), Mongo.Collection);
   test.instanceOf(Mongo.Collection.get('users'), Meteor.Collection);
 });
+
+Tinytest.add('local collections - can get local collections instance', function (test) {
+  var collection = new Mongo.Collection(null); //create a new local collection
+  
+  //inject the name
+  var collectionName = 'test' + test.id;
+  collection._name = collection._collection.name = collectionName;
+  
+  var collectionFromMongoCollectionGet = Mongo.Collection.get(collectionName);
+  
+  test.equal(collectionFromMongoCollectionGet, collection, 'local collections - can get local collections instance');
+});

--- a/mongo-instances.js
+++ b/mongo-instances.js
@@ -12,9 +12,9 @@ Mongo.Collection.get = function(name, options) {
   options = options || {};
   var collection = _.find(instances, function(instance) {
     if (options.connection)
-      return instance.name === name &&
+      return (instance.name === name || instance.instance._name === name) &&
         instance.options && instance.options.connection._lastSessionId === options.connection._lastSessionId;
-    return instance.name === name;
+    return instance.name === name || instance.instance._name === name;
   });
 
   return collection && collection.instance;

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'dburles:mongo-collection-instances',
   summary: 'Access your Mongo instances',
-  version: '0.3.5',
+  version: '0.3.6',
   git: 'https://github.com/dburles/mongo-collection-instances.git'
 });
 


### PR DESCRIPTION
after defining a new local collection:
`var collection = new Mongo.Collection(null);`

and assigning a name for it:
`collection._name = collection._collection.name = 'a_name_so_i_can_get_it'`;

we can later retrieve it with:
`var sameCollection = Mongo.Collection.get('a_name_so_i_can_get_it')`;
