### PR TITLE
API - remove function added

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,15 @@ Returns an array of objects containing:
  - instance (The collection instance)
  - options (Any options that were passed in on instantiation)
 
-#### Mongo.Collection.remove('name')
+#### Mongo.Collection.remove('name', [options])
 
 Removes the collection from the instances list. Does **not** drop the collection.
 
+ - name (String)
+ - options (Object) [optional]
+   - options.connection (A connection object)
+
+Note, that if multiple connections are used and no connection is given as option, the first match of 'name' will be removed.
 
 ## Multiple connections
 
@@ -60,6 +65,8 @@ Mongo.Collection.get('foo') // returns instance of Foo1
 
 Mongo.Collection.get('foo', { connection: connection }); // returns instance of Foo2
 ```
+
+
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Returns an array of objects containing:
  - instance (The collection instance)
  - options (Any options that were passed in on instantiation)
 
+#### Mongo.Collection.remove('name')
+
+Removes the collection from the instances list. Does **not** drop the collection.
+
 
 ## Multiple connections
 

--- a/mongo-instances-tests.js
+++ b/mongo-instances-tests.js
@@ -68,3 +68,20 @@ Tinytest.add('users - can Mongo.Collection.get Meteor.users instance', function 
   test.instanceOf(Mongo.Collection.get('users'), Mongo.Collection);
   test.instanceOf(Mongo.Collection.get('users'), Meteor.Collection);
 });
+
+Tinytest.add('remove - removes the entry from instances', function (test) {
+	var collectionName = 'test' + test.id;
+	var Test = new Mongo.Collection(collectionName);
+	var expectRemoved = Mongo.Collection.remove(collectionName);
+	test.equal(expectRemoved, true);
+	var expectNoCollection = Mongo.Collection.get(collectionName);
+	test.equal(expectNoCollection, undefined);
+});
+
+Tinytest.add('remove - returns false on a non-listed instance name', function (test) {
+	var collectionName = 'test' + test.id;
+	var expectFalse = Mongo.Collection.remove(collectionName);
+	test.equal(expectFalse, false);
+	var expectNoCollection = Mongo.Collection.get(collectionName);
+	test.equal(expectNoCollection, undefined);
+});

--- a/mongo-instances-tests.js
+++ b/mongo-instances-tests.js
@@ -85,3 +85,13 @@ Tinytest.add('remove - returns false on a non-listed instance name', function (t
 	var expectNoCollection = Mongo.Collection.get(collectionName);
 	test.equal(expectNoCollection, undefined);
 });
+
+Tinytest.add('remove - does not remove a local collection if a non-existent connection is passed', function (test) {
+	var collectionName = 'test' + test.id;
+	var Test = new Mongo.Collection(collectionName);
+	var mockConnection = {_lastSessionId:"0123456789"};
+	var expectFalse = Mongo.Collection.remove(collectionName, {connection: mockConnection});
+	test.equal(expectFalse, false);
+	var expectCollection = Mongo.Collection.get(collectionName);
+	test.instanceOf(expectCollection, Mongo.Collection);
+});

--- a/mongo-instances.js
+++ b/mongo-instances.js
@@ -24,5 +24,21 @@ Mongo.Collection.getAll = function() {
   return instances;
 };
 
+Mongo.Collection.remove = function (name) {
+  var index = -1;
+  for (var i = 0; i < instances.length; i++) {
+    if (name === instances[i].name) {
+      index = i;
+      break;
+    }
+  }
+  if (index > -1) {
+    instances.splice(index, 1);
+    return true;
+  } else {
+    return false;
+  }
+};
+
 // Meteor.Collection will lack ownProperties that are added back to Mongo.Collection
 Meteor.Collection = Mongo.Collection;

--- a/mongo-instances.js
+++ b/mongo-instances.js
@@ -29,11 +29,12 @@ Mongo.Collection.remove = function (name, options) {
   var connectionId = options && options.connection ? options.connection._lastSessionId : null;
   for (var i = 0; i < instances.length; i++) {
     var instance = instances[i];
-    if (connectionId && instance.options.connection._lastSessionId === connectionId && name === instance.name) {
+    if (connectionId && instance.options && instance.options.connection &&
+        instance.options.connection._lastSessionId === connectionId && name === instance.name) {
 	    index = i;
 	    break;
     }
-    else if (name === instance.name) {
+    else if (!connectionId && name === instance.name) {
       index = i;
       break;
     }

--- a/mongo-instances.js
+++ b/mongo-instances.js
@@ -24,10 +24,16 @@ Mongo.Collection.getAll = function() {
   return instances;
 };
 
-Mongo.Collection.remove = function (name) {
+Mongo.Collection.remove = function (name, options) {
   var index = -1;
+  var connectionId = options && options.connection ? options.connection._lastSessionId : null;
   for (var i = 0; i < instances.length; i++) {
-    if (name === instances[i].name) {
+    var instance = instances[i];
+    if (connectionId && instance.options.connection._lastSessionId === connectionId && name === instance.name) {
+	    index = i;
+	    break;
+    }
+    else if (name === instance.name) {
       index = i;
       break;
     }

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'dburles:mongo-collection-instances',
   summary: 'Access your Mongo instances',
-  version: '0.3.5',
+  version: '0.4.0',
   git: 'https://github.com/dburles/mongo-collection-instances.git'
 });
 


### PR DESCRIPTION
**Implementation**

Removes an instance object by a given name and the matching name attribute. If found and removed it returns true, otherwise false.

If connection is given as option, it looks explicitly for instances with connection options and removes them only on connection last sesison id AND name match.

If no connection is given as option it removes the first occurence by name.

**Tests**

Implemented and working for the above described behavior.

**Reason**

I needed this function because there were 

a) collections I wanted to prevent to be accessible via Mongo.Collection.get without having another class been build around this and

b) entries in instances were left, when I dropped collections within my application.

